### PR TITLE
Fix ml_service Dockerfile path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
   ml_service:
     build:
       context: ./backend
-      dockerfile: Dockerfile.ml
+      dockerfile: Dockerfile
     container_name: ppe_ml
     environment:
       - REDIS_URL=redis://redis:6379


### PR DESCRIPTION
## Summary
- fix `dockerfile` path for `ml_service` in `docker-compose.yml`

## Testing
- `pytest -q` *(fails: no tests ran)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e878ffb44832fb48d06e5f810f888